### PR TITLE
修复了仙人掌魔石的巫师魔石tooltip会直接显示路径

### DIFF
--- a/Localization/FargoSouls/zh-Hans.hjson
+++ b/Localization/FargoSouls/zh-Hans.hjson
@@ -8,6 +8,8 @@
 
 Mods: {
 	FargowiltasSouls: {
+		WizardEffecCactus: ""
+		//Terry收了魂石官汉后把这个删了
 		WizardEffect:{
 			Adamantite: 弹幕现在会分裂成三个，造成33%伤害，造成伤害的频率提升到3倍
 			AncientHallow: ""


### PR DESCRIPTION
暴力方法：直接给对应路径加上应有的东西（